### PR TITLE
Only require QtTest library when building tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_AUTORCC ON)
 option(BUILD_TESTS "Build Unit Tests" OFF)
 option(BUILD_EXAMPLE "Build Example Application" ON)
 
-find_package(Qt5 ${QT_MIN_VERSION} REQUIRED Widgets Test)
+find_package(Qt5 ${QT_MIN_VERSION} REQUIRED Widgets)
 
 include(GNUInstallDirs)
 include(FeatureSummary)
@@ -25,6 +25,7 @@ if (BUILD_EXAMPLE)
 endif (BUILD_EXAMPLE)
 
 if (BUILD_TESTS)
+    find_package(Qt5 ${QT_MIN_VERSION} REQUIRED Test)
     enable_testing()
     add_subdirectory(tests)
 endif (BUILD_TESTS)


### PR DESCRIPTION
Hi, looking at making packages for Gentoo, and this would help with the ebuild.