### PR TITLE
Fix cmake_minimum_required version range typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10..3.31)
+cmake_minimum_required(VERSION 3.10...3.31)
 project(kColorPicker LANGUAGES CXX VERSION 0.3.1)
 
 set(QT_MIN_VERSION 5.15.2)


### PR DESCRIPTION
While CMake appears to accept the ".." notation, it does not correctly apply the policy_max version in that case.

Amends d91ba101b65bc9e2a5506959295472ed42bde943

(@DamirPorobic sorry about that one)